### PR TITLE
Added support for servers that require you to type password twice in /register

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var authCommand = require('./lib/generate-auth');
+var authCommandDouble = require('./lib/generate-auth-double');
 
 module.exports = function(bot, botConfig) {
   // Detect possible login/register failure
@@ -26,6 +27,7 @@ module.exports = function(bot, botConfig) {
 
   bot.on('registerRequest', function() {
     bot.chat(authCommand('register', config.password));
+    bot.chat(authCommandDouble('register', config.password));
     if(config.logging) {
       console.log('Got register request');
     }

--- a/lib/generate-auth-double.js
+++ b/lib/generate-auth-double.js
@@ -1,0 +1,9 @@
+module.exports = function(type, password) {
+  var command = '/' + type + ' ' + password;
+
+  if(type === 'register') {
+    command += ' ' + password + ' ' + password;
+  }
+
+  return command;
+};


### PR DESCRIPTION
The title says it all. If a server requires you to type the password "abc123" twice in the /register command, now the module can handle that scenario!

Example: /register <password> <password>